### PR TITLE
Added vein count option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Each entry must consist of at least two objects:
 
 Each ore entry can also have the following properties. If they are not present they will assume their default value.
 
+* `count` (Default: 1) Generate at most N veins per chunk. Rarity is applied to each attempt to generate a vein.
 * `rarity` (Default: 10) 1 / N chunks will spawn this ore vein.
 * `density` (Default: 50) Controls the density of ore veins. Higher values are more dense. Experimentation required for best results.
 * `min_y` (Default: 16) Minimum y value for veins to generate at.

--- a/src/main/java/oreveins/GenHandler.java
+++ b/src/main/java/oreveins/GenHandler.java
@@ -102,6 +102,7 @@ public class GenHandler {
     @Nonnull
     private static Ore parseOreEntry(Config config) throws IllegalArgumentException {
 
+        final int count = getValue(config, "count", 1);
         final int rarity = getValue(config, "rarity", 10);
         final int density = getValue(config, "density", 50);
         final int minY = getValue(config, "min_y", 16);
@@ -120,7 +121,7 @@ public class GenHandler {
         boolean dimIsWhitelist = getBoolean(config, "dimensions_is_whitelist");
         boolean biomesIsWhitelist = getBoolean(config, "biomes_is_whitelist");
 
-        return new Ore(oreStates, stoneStates, rarity, minY, maxY, density, horizontalSize, verticalSize, biomes, dims, dimIsWhitelist, biomesIsWhitelist);
+        return new Ore(oreStates, stoneStates, count, rarity, minY, maxY, density, horizontalSize, verticalSize, biomes, dims, dimIsWhitelist, biomesIsWhitelist);
     }
 
     @Nonnull
@@ -232,6 +233,7 @@ public class GenHandler {
         public final LinkedListMultimap<IBlockState, Integer> oreStates;
         public final List<IBlockState> stoneStates;
 
+        public final int count;
         public final int rarity;
         public final int minY;
         public final int maxY;
@@ -246,11 +248,12 @@ public class GenHandler {
         public final boolean biomesIsWhitelist;
 
         public Ore(@Nonnull LinkedListMultimap<IBlockState, Integer> oreStates, @Nonnull List<IBlockState> stoneStates,
-                   int rarity, int minY, int maxY, int density, int horizontalSize, int verticalSize,
+                   int count, int rarity, int minY, int maxY, int density, int horizontalSize, int verticalSize,
                    @Nullable List<String> biomes, @Nullable List<Integer> dims, boolean dimensionIsWhitelist, boolean biomesIsWhitelist) {
             this.oreStates = oreStates;
             this.stoneStates = stoneStates;
 
+            this.count = count;
             this.rarity = rarity;
             this.minY = minY;
             this.maxY = maxY;

--- a/src/main/java/oreveins/world/WorldGenVeins.java
+++ b/src/main/java/oreveins/world/WorldGenVeins.java
@@ -89,14 +89,16 @@ public class WorldGenVeins implements IWorldGenerator {
         List<VeinTypeCluster> veins = new ArrayList<>();
 
         for (GenHandler.Ore ore : ORE_SPAWN_DATA) {
-            if (rand.nextInt(ore.rarity) == 0) {
-                BlockPos startPos = new BlockPos(
+            for (int i = 0; i < ore.count; i++) {
+                if (rand.nextInt(ore.rarity) == 0) {
+                    BlockPos startPos = new BlockPos(
                         chunkX * 16 + rand.nextInt(16),
                         ore.minY + rand.nextInt(ore.maxY - ore.minY),
                         chunkZ * 16 + rand.nextInt(16)
-                );
-                VeinTypeCluster vein = new VeinTypeCluster(ore, startPos, rand);
-                veins.add(vein);
+                    );
+                    VeinTypeCluster vein = new VeinTypeCluster(ore, startPos, rand);
+                    veins.add(vein);
+                }
             }
         }
         return veins;

--- a/src/main/resources/assets/ore_veins.json
+++ b/src/main/resources/assets/ore_veins.json
@@ -1,7 +1,8 @@
 {
   "iron_ore_example": {
     "ore": "minecraft:iron_ore",
-    "stone": "minecraft:stone"
+    "stone": "minecraft:stone",
+    "count": 3
   },
   "gold_ore_example": {
     "ore": "minecraft:gold_ore",


### PR DESCRIPTION
I added a count option to the config JSON so you can generate many small veins vs. opposed single large veins. Existing behavior should be exactly the same since count defaults to 1.